### PR TITLE
Improve minDate & maxDate handling

### DIFF
--- a/HSDatePickerViewControllerDemo/HSDatePickerViewController/HSDatePickerViewController.m
+++ b/HSDatePickerViewControllerDemo/HSDatePickerViewController/HSDatePickerViewController.m
@@ -339,12 +339,16 @@ static NSInteger kBufforRows = 30; //Number of rows that are prevent by scroll p
     if (firstComponentRowValue <= self.minRowIndex) {
         NSDateComponents *components = [[NSCalendar currentCalendar] components:(NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:self.minDate];
         [self setPickerView:self.pickerView rowInComponent:HourPicker toIntagerValue:[components hour] decrementing:NO animated:YES];
-        [self setPickerView:self.pickerView rowInComponent:MinutePicker toIntagerValue:[components minute]  decrementing:NO animated:YES];
+        if ([pickerView selectedRowInComponent:HourPicker] <= [self defaultRowValueForComponent:HourPicker] + [components hour]) {
+            [self setPickerView:self.pickerView rowInComponent:MinutePicker toIntagerValue:[components minute]  decrementing:NO animated:YES];
+        }
     }
     if (firstComponentRowValue >= self.maxRowIndex) {
         NSDateComponents *components = [[NSCalendar currentCalendar] components:(NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:self.maxDate];
         [self setPickerView:self.pickerView rowInComponent:HourPicker toIntagerValue:[components hour] decrementing:YES animated:YES];
-        [self setPickerView:self.pickerView rowInComponent:MinutePicker toIntagerValue:[components minute]  decrementing:YES animated:YES];
+        if ([pickerView selectedRowInComponent:HourPicker] >= [self defaultRowValueForComponent:HourPicker] + [components hour]) {
+            [self setPickerView:self.pickerView rowInComponent:MinutePicker toIntagerValue:[components minute]  decrementing:YES animated:YES];
+        }
     }
 }
 


### PR DESCRIPTION
The scrolling to the next possible date didn't always work as expected. Let's say you've got 19:15 as a minimum time, you can't set 20:10, although obviously it's valid. We should only be resetting the minute if needed, like we do with the date.
